### PR TITLE
ESTS-137547 Ensure all rackhd images included in rpm

### DIFF
--- a/rackhd/Dockerfile
+++ b/rackhd/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/rackhd/on-taskgraph:2.29.0
+FROM docker.io/rackhd/on-taskgraph:2.30.0
 
 RUN echo 'deb http://linux.dell.com/repo/community/ubuntu wheezy openmanage' | tee -a /etc/apt/sources.list.d/linux.dell.com.sources.list
 RUN gpg --keyserver hkp://pool.sks-keyservers.net:80 --recv-key 1285491434D8786F

--- a/rackhd/build_rpm
+++ b/rackhd/build_rpm
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 #
 # Copyright 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 # Dell EMC Confidential/Proprietary Information.
@@ -35,7 +35,7 @@ process_docker save rackhd/docker-compose.yml
 
 # Customize on-taskgraph for idracadm7
 docker build -t rackhd/on-taskgraph:${TAG}-symphony rackhd/
-docker save rackhd/on-taskgraph:${TAG}-symphony >  ${TARGET_DIR}/rackhd_taskgraph.tar
+docker save rackhd/on-taskgraph:${TAG}-symphony >  ${TARGET_DIR}/rackhd-taskgraph.tar
 
 wget http://artifactory.mpe.lab.vce.com:8080/artifactory/cpsd-generic-files/rackhd-artifacts/secure.erase.overlay.cpio-1.gz -O rackhd/secure.erase.overlay.cpio.gz
 wget http://artifactory.mpe.lab.vce.com:8080/artifactory/cpsd-generic-files/rackhd-artifacts/ESXi-3299935-vce-Quanta.iso -O rackhd/ESXi-3299935-vce-Quanta.iso

--- a/rackhd/lib/process_docker
+++ b/rackhd/lib/process_docker
@@ -1,43 +1,38 @@
-#!/usr/bin/env sh
-#
-# WARNING: This breaks when run under bash.
+#!/usr/bin/env bash
 
 process_docker() {
    action=$1
    compose_file=$2
 
-   eval $(local s='[[:space:]]*' w='[a-zA-Z0-9_]*' fs=$(echo @|tr @ '\034')
-   sed -ne "s|^\($s\)\($w\)$s:$s\"\(.*\)\"$s\$|\1$fs\2$fs\3|p" \
-        -e "s|^\($s\)\($w\)$s:$s\(.*\)$s\$|\1$fs\2$fs\3|p"  $compose_file |
-   awk -F$fs '{
-      indent = length($1)/2;
-      vname[indent] = $2;
-      for (i in vname) {if (i > indent) {delete vname[i]}}
-      if (length($3) > 0) {
-         vn=""; for (i=0; i<indent; i++) {vn=(vn)(vname[i])("_")}
-         printf("%s%s=\"%s\"\n",vn, $2, $3);
-      }
-   }')
+   tmpfile=$(mktemp)
 
-   for var in $(set | strings | grep -e 'services_.\+_image=' | sed -e 's|services_\(.\+\)_image=|\1=|')
-   do
-      key=$(echo $var | cut -d= -f1)
-      value=$(echo $var | cut -d= -f2- | tr -d "'")
+   # Save standardized, validated config
+   pushd `dirname $compose_file`
+   docker-compose config > $tmpfile
 
-      case $action in
-         save )
-            docker pull $value
-            docker save $value > ${TARGET_DIR}/$key.tar
-            ;;
+   containers=($(awk '{if ($1 == "container_name:") print $2;}' $tmpfile))
+   images=($(awk '{if ($1 == "image:") print $2;}' $tmpfile))
 
-         load )
-            docker load -i ../image/$key.tar
-            ;;
+   rm $tmpfile
+   popd
 
-         delete )
-            docker rmi $value
-            ;;
-      esac
+   for ((i=0;i<${#containers[@]};++i)); do
+       container=${containers[$i]}
+       image=${images[$i]}
 
+       case $action in
+           save )
+               docker pull $image
+               docker save $image > ${TARGET_DIR}/$container.tar
+               ;;
+
+           load )
+               docker load -i ../image/$container.tar
+               ;;
+
+           delete )
+               docker rmi $image
+               ;;
+       esac
    done
 }

--- a/rackhd/rackhd.spec
+++ b/rackhd/rackhd.spec
@@ -98,9 +98,9 @@ exit 0
 ##############################################################################
 %post
 if [ $1 -eq 1 ];then
-    /bin/sh /opt/dell/cpsd/rackhd/install/install.sh
+    /opt/dell/cpsd/rackhd/install/install.sh
 elif [ $1 -eq 2 ];then
-    /bin/sh /opt/dell/cpsd/rackhd/install/upgrade.sh
+    /opt/dell/cpsd/rackhd/install/upgrade.sh
 else
     echo "Unexpected argument passed to RPM %post script: [$1]"
     exit 1


### PR DESCRIPTION
This is a copy of changes that were made in the
thirdparty-rpm-generator q3stable branch:

- Rework process_docker method so that it pulls in all images required
  by the RackHD `docker-compose.yml` file. Previously the SMI
  micro-services and other images were missing. Generally they would
  get downloaded on the RackHD appliance when the RPM was installed
  but this can fail if there are connectivity issues. As a side-effect
  `process_docker` now supports / requires bash. Previously it only
  worked with sh.

- The wrong `rackhd-taskgraph` version was being used as a base in the
  custom rackhd-taskgraph image that was being built.