### PR TITLE
ESTS-138081 Add custom RHEL packages and disk cleanup

### DIFF
--- a/on-taskgraph/Dockerfile
+++ b/on-taskgraph/Dockerfile
@@ -24,3 +24,14 @@ RUN patch -p1 -d /RackHD/on-taskgraph < on-taskgraph-esx-clearpart-6cb8a5a.patch
 
 COPY patches/on-tasks-esx-clearpart-a5ba0af.patch ./
 RUN patch -p1 -d /RackHD/on-tasks < on-tasks-esx-clearpart-a5ba0af.patch
+
+# Add RHEL installer options for adding packages and clearing partitions
+#
+# https://github.com/RackHD/on-taskgraph/pull/343
+# https://github.com/RackHD/on-tasks/pull/568
+
+COPY patches/on-taskgraph-dne-rhel-583e0f2.patch ./
+RUN patch -p1 -d /RackHD/on-taskgraph < on-taskgraph-dne-rhel-583e0f2.patch
+
+COPY patches/on-tasks-dne-rhel-19b89dd.patch ./
+RUN patch -p1 -d /RackHD/on-tasks < on-tasks-dne-rhel-19b89dd.patch

--- a/on-taskgraph/patches/on-taskgraph-dne-rhel-583e0f2.patch
+++ b/on-taskgraph/patches/on-taskgraph-dne-rhel-583e0f2.patch
@@ -1,0 +1,145 @@
+commit 583e0f203120302dbf77ffce1765ff5f28098d17
+Author: Sushil Rai <sushil_r@dell.com>
+Date:   Tue Dec 5 20:41:14 2017 +0530
+
+    Included support for RHE72
+    
+    - Added support for installing additional packages / group packages
+    - Including copyright text
+    - Configuring NIC Bond
+    - IP Gateway optional for non-routed network
+    - Enable / Disable services during post-installation
+
+diff --git a/data/templates/centos-ks b/data/templates/centos-ks
+index 45db40c..8cd3ae6 100755
+--- a/data/templates/centos-ks
++++ b/data/templates/centos-ks
+@@ -1,3 +1,4 @@
++# Copyright 2017, DELL, Inc.
+ install
+ #text
+ graphical
+@@ -84,6 +85,7 @@ sudo
+ perl
+ libselinux-python
+ net-tools
++
+ <% if( typeof kvm !== 'undefined' && kvm ) { %>
+     <% if (version === "6.5") { %>
+         kvm
+@@ -98,6 +100,12 @@ net-tools
+         @virtualization-tools
+     <% } %>
+ <% } %>
++
++<% if (typeof packages !== 'undefined') { %>
++<%   for (var i = 0, len = packages.length; i < len; i++) { %>
++<%= packages[i] %>
++<%   } %>
++<% } %>
+ %end
+ 
+ %pre
+@@ -107,6 +115,7 @@ net-tools
+     # the url may contain query, the symbol '&' will mess the command line logic, so the whole url need be wrapped in quotation marks
+     /usr/bin/curl -X POST -H 'Content-Type:application/json' "http://<%=server%>:<%=port%><%-progressMilestones.preConfigUri%>" || true
+ <% } %>
++
+ %end
+ 
+ %post --log=/root/install-post.log
+@@ -147,6 +156,58 @@ export PATH
+     <% } %>
+ <% } %>
+ 
++# Setup BOND Configuration
++<% if (typeof bonds !== 'undefined') { %> 
++
++<% bonds.forEach(function(n) { %>
++     echo "Configuring bond <%=n.name%>"
++     <% var bondname = n.name %>
++     echo DEVICE=<%=bondname%> > /etc/sysconfig/network-scripts/ifcfg-<%=n.name%>
++     echo NAME=<%=bondname%> >> /etc/sysconfig/network-scripts/ifcfg-<%=n.name%>
++     echo TYPE=bond  >> /etc/sysconfig/network-scripts/ifcfg-<%=n.name%>
++     echo BONDING_MASTER=yes >> /etc/sysconfig/network-scripts/ifcfg-<%=n.name%>
++     echo BONDING_OPTS="mode=802.3ad miimon=10 lacp_rate=1"  >> /etc/sysconfig/network-scripts/ifcfg-<%=n.name%>
++     echo USERCTL=no >> /etc/sysconfig/network-scripts/ifcfg-<%=n.name%>
++     echo NM_CONTROLLED=no >> /etc/sysconfig/network-scripts/ifcfg-<%=n.name%>
++     echo BOOTPROTO=none >> /etc/sysconfig/network-scripts/ifcfg-<%=n.name%>
++     echo ONBOOT=yes >> /etc/sysconfig/network-scripts/ifcfg-<%=n.name%>
++     echo IPADDR="<%=n.ipv4.ipAddr%>" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.name%>
++     echo NETMASK="<%=n.ipv4.netmask%>" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.name%>
++     <% if ( undefined != n.ipv4.gateway) { %>
++          echo GATEWAY="<%=n.ipv4.gateway%>" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.name%>
++     <% } %>
++     echo DEFROUTE=yes >> /etc/sysconfig/network-scripts/ifcfg-<%=n.name%>
++     echo PEERDNS=yes >> /etc/sysconfig/network-scripts/ifcfg-<%=n.name%>
++
++     <% if ( undefined != n.ipv4.dns1) { %>
++        echo DNS1="<%=n.ipv4.dns1%>" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.name%>
++     <% } %>
++     <% if ( undefined != n.ipv4.dns2) { %>
++        echo DNS2="<%=n.ipv4.dns2%>" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.name%>
++     <% } %>
++
++     echo IPV4_FAILURE_FATAL="no" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.name%>
++     echo IPV6INIT="no" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.name%>
++     <% if (typeof n.nics !== 'undefined') { %>
++      <%   for (var i = 0, len = n.nics.length; i < len; i++) { %>
++        <% var device=n.nics[i]%>
++        echo DEVICE=<%=device%> > /etc/sysconfig/network-scripts/ifcfg-<%=device%>
++        echo NAME=<%=bondname%>-slave >> /etc/sysconfig/network-scripts/ifcfg-<%=device%>
++        echo MASTER=<%=bondname%> >> /etc/sysconfig/network-scripts/ifcfg-<%=device%>
++        echo TYPE=Ethernet >> /etc/sysconfig/network-scripts/ifcfg-<%=device%>
++        echo BOOTPROTO=none >> /etc/sysconfig/network-scripts/ifcfg-<%=device%>
++        echo ONBOOT=yes >> /etc/sysconfig/network-scripts/ifcfg-<%=device%>
++        echo NM_CONTROLLED=no >> /etc/sysconfig/network-scripts/ifcfg-<%=device%>
++        echo SLAVE=yes >> /etc/sysconfig/network-scripts/ifcfg-<%=device%>
++      <%   } %>
++      <% } %>     
++  <%}) %>
++  
++  systemctl stop NetworkManager
++  modprobe --first-time bonding
++  systemctl restart network
++<%} %>
++
+ # Setup static network configuration
+ <%_ var macRegex = /(..:*){6}/i; _%>
+ <% if (typeof networkDevices !== 'undefined') { %>
+@@ -182,7 +243,13 @@ export PATH
+         echo "ONBOOT=yes" >> /etc/sysconfig/network-scripts/ifcfg-$interface
+         echo "IPADDR=<%=n.ipv4.ipAddr%>" >> /etc/sysconfig/network-scripts/ifcfg-$interface
+         echo "NETMASK=<%=n.ipv4.netmask%>" >> /etc/sysconfig/network-scripts/ifcfg-$interface
+-        echo "GATEWAY=<%=n.ipv4.gateway%>" >> /etc/sysconfig/network-scripts/ifcfg-$interface
++        <% if ( undefined != n.ipv4.gateway) { %>
++          echo "GATEWAY=<%=n.ipv4.gateway%>" >> /etc/sysconfig/network-scripts/ifcfg-$interface
++        <% } %>
++        <% if ( undefined != n.ipv4.mtu) { %>
++          echo "MTU=<%=n.ipv4.mtu%>" >> /etc/sysconfig/network-scripts/ifcfg-$interface
++        <% } %>
++
+       <% } %>
+     <% } %>
+     <% if( undefined != n.ipv6 ) { %>
+@@ -239,6 +306,20 @@ chmod +x /etc/rc.d/init.d/<%=rackhdCallbackScript%>
+ chkconfig <%=rackhdCallbackScript%> on
+ echo "RackHD POST script chkconfig callback script complete"
+ 
++# Enable Services
++<% if (typeof enableServices !== 'undefined') { %>
++<%   for (var i = 0, len = enableServices.length; i < len; i++) { %>
++systemctl enable <%=enableServices[i]%>
++<%   } %>
++<% } %>
++
++# Disable Services
++<% if (typeof disableServices !== 'undefined') { %>
++<%   for (var i = 0, len = disableServices.length; i < len; i++) { %>
++systemctl disable <%=disableServices[i]%>
++<%   } %>
++<% } %>
++
+ #signify ORA the installation completed
+ for retry in $(seq 1 5);
+ do

--- a/on-taskgraph/patches/on-tasks-dne-rhel-19b89dd.patch
+++ b/on-taskgraph/patches/on-tasks-dne-rhel-19b89dd.patch
@@ -1,0 +1,161 @@
+commit 19b89dd095b11b7e3e48e4c2f73668ef317ee903
+Author: Sushil Rai <sushil_r@dell.com>
+Date:   Tue Dec 5 20:26:17 2017 +0530
+
+    RHEL 7.2 installation support
+    
+    -  Added support for additional packages
+    -  NIC Bond
+    -  MTU configuration
+    -  Configuring IP gateway as option to non-routable networks
+    -  Enable / Disable list of services
+
+diff --git a/lib/jobs/install-os.js b/lib/jobs/install-os.js
+index ca5a6a0..a68f162 100755
+--- a/lib/jobs/install-os.js
++++ b/lib/jobs/install-os.js
+@@ -93,7 +93,6 @@ function installOsJobFactory(
+                 assert.string(dev.device);
+                 if (dev.ipv4) {
+                     assert.isIP(dev.ipv4.ipAddr, 4);
+-                    assert.isIP(dev.ipv4.gateway, 4);
+                     assert.string(dev.ipv4.netmask);
+                     _.forEach(dev.ipv4.netmask.split('.'), function(item) {
+                         item = +item ? +item : parseInt(item, 16);
+diff --git a/lib/task-data/schemas/install-centos.json b/lib/task-data/schemas/install-centos.json
+index 32dcd8c..7b89c7f 100644
+--- a/lib/task-data/schemas/install-centos.json
++++ b/lib/task-data/schemas/install-centos.json
+@@ -50,6 +50,9 @@
+         "networkDevices": {
+             "$ref": "types-installos.json#/definitions/NetworkDeviceArray"
+         },
++        "bonds": {
++            "$ref": "types-installos.json#/definitions/BondsArray"
++        },
+         "kvm": {
+             "$ref": "types-installos.json#/definitions/Kvm"
+         },
+@@ -61,6 +64,15 @@
+         },
+         "progressMilestones": {
+             "$ref": "types-installos.json#/definitions/ProgressMilestones"
++        },
++        "packages": {
++            "$ref": "types-installos.json#/definitions/PackagesArray"
++        },
++        "disableServices": {
++            "$ref": "types-installos.json#/definitions/DisableServices"
++        },
++        "enableServices": {
++            "$ref": "types-installos.json#/definitions/EnableServices"
+         }
+     },
+     "required": ["osType", "version", "repo", "profile", "installScript",
+diff --git a/lib/task-data/schemas/types-installos.json b/lib/task-data/schemas/types-installos.json
+index 31f621c..83ca130 100644
+--- a/lib/task-data/schemas/types-installos.json
++++ b/lib/task-data/schemas/types-installos.json
+@@ -107,9 +107,15 @@
+                         "$ref": "#/definitions/VlanId"
+                     },
+                     "uniqueItems": true
++                },
++                "mtu": {
++                    "description": "The ipv4 MTU",
++                    "type": "integer",
++                    "minimum": 1500,
++                    "maximum": 9026
+                 }
+             },
+-            "required": ["ipAddr", "netmask", "gateway"],
++            "required": ["ipAddr", "netmask"],
+             "additionalProperties": false
+         },
+         "Ipv6Configuration": {
+@@ -165,6 +171,38 @@
+             "required": ["device"],
+             "additionalProperties": true
+         },
++        "Nics": {
++            "description": "List of NICs",
++            "type": "array",
++            "items": {
++                "type": "string"
++            },
++            "uniqueItems": true
++        },
++        "BondConfig": {
++            "description": "Bond Interface configuration",
++            "type": "object",
++            "properties": {
++                "name": {
++                    "description": "The bond interface name.",
++                    "type": "string"
++                },
++                "nics": {
++                    "description": "the ipv4 configuration for this interface",
++                    "$ref": "#/definitions/Nics"
++                },
++                "ipv4": {
++                    "description": "the ipv4 configuration for this interface",
++                    "$ref": "#/definitions/Ipv4Configuration"
++                },
++                "ipv6": {
++                    "description": "the ipv6 configuration for this interface",
++                    "$ref": "#/definitions/Ipv6Configuration"
++                }
++            },
++            "required": ["name"],
++            "additionalProperties": true
++        },
+         "NetworkDeviceArray": {
+             "description": "The network configuration for each NIC",
+             "type": "array",
+@@ -174,6 +212,15 @@
+             },
+             "uniqueItems": true
+         },
++        "BondsArray": {
++            "description": "Bond Interface configuration definition",
++            "type": "array",
++            "minItems": 1,
++            "items": {
++                "$ref": "#/definitions/BondConfig"
++            },
++            "uniqueItems": true
++        },
+         "PartitionConfig": {
+             "description": "The configuration for a disk partition",
+             "type": "object",
+@@ -319,6 +366,30 @@
+             "type": "string",
+             "description": "Extra (persistent) kernel boot parameters",
+             "minLength": 1
++        },
++        "PackagesArray": {
++            "description": "specify additional packages to install",
++            "type": "array",
++            "items": {
++                "type": "string"
++            },
++            "uniqueItems": true
++        },
++        "EnableServices": {
++            "description": "List of services that needs to be enabled explicitly during post-installation phase",
++            "type": "array",
++            "items": {
++                "type": "string"
++            },
++            "uniqueItems": true
++        },
++        "DisableServices": {
++            "description": "List of services that needs to be disabled during post-installation phase",
++            "type": "array",
++            "items": {
++                "type": "string"
++            },
++            "uniqueItems": true
+         }
+     }
+ }


### PR DESCRIPTION
ScaleIO storage-only nodes on RHEL require custom RPM packages to be
installed and to have disk partitions cleared. This adds that support
into the RackHD Graph.InstallRHEL workflow. The changes have been
submitted upstream as:

- https://github.com/RackHD/on-taskgraph/pull/343
- https://github.com/RackHD/on-tasks/pull/568