### PR TITLE
[maint] Fail the build if any steps fail

### DIFF
--- a/build_rpm
+++ b/build_rpm
@@ -4,6 +4,7 @@
 # Dell EMC Confidential/Proprietary Information.
 #
 
+set -o errexit
 set -x
 
 SPEC_PATH=$(dirname $(realpath $1))

--- a/create_rpms
+++ b/create_rpms
@@ -4,6 +4,8 @@
 # Dell EMC Confidential/Proprietary Information
 #
 
+set -o errexit
+
 # check if --debug flag is set
 if [[ "$1" == "--debug" || "$1" == "-d" ]]; then
   set -x


### PR DESCRIPTION
The build scripts previously would continue even if any steps failed
which can lead to bad builds. For example on-taskgraph [failed to
build][1] with this error:

    13:50:45 mThe command '/bin/sh -c gpg --keyserver hkp://pool.sks-keyservers.net:80 --recv-key 1285491434D8786F' returned a non-zero code: 2

This resulted in an on-taskgraph rpm with an empty taskgraph docker
image and the failure of RackHD to start.

[1]: http://ci-build.mpe.lab.vce.com:8080/job/dellemc-symphony4/job/rackhd-packaging/job/master/17/